### PR TITLE
chore: release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,48 @@
-# Changelog
+## [1.0.4](https://github.com/daniissac/servelite/compare/v1.0.3...v1.0.4) (2024-11-17)
 
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+### Bug Fixes
 
-## [1.0.0] - 2024-02-17
+* improve GitHub Actions workflows and fix Tauri configuration ([4b171c6](https://github.com/daniissac/servelite/commit/4b171c6fe1548c9c7c0bceb80db39546f270d9cb))
 
-### Added
-- Auto port selection (8000-8099)
-- Live reload support via WebSocket
-- Recent directories menu (up to 5 entries)
-- Copy URL feature
-- System tray integration
-- Cross-platform support (macOS, Linux, Windows)
 
-### Changed
-- Updated to Node.js 20
-- Improved error handling
-- Enhanced build process
 
-### Security
-- CORS enabled
-- Local network serving only
-- Optimized release profile
-- Link-time optimizations
+## [1.0.3](https://github.com/daniissac/servelite/compare/v1.0.2...v1.0.3) (2024-11-17)
+
+
+### Bug Fixes
+
+* simplify checkout configuration ([2a1a9f5](https://github.com/daniissac/servelite/commit/2a1a9f5b10e691618de7bce76bcf0d81a3b49ca3))
+* use PAT_TOKEN for workflow authentication ([7157847](https://github.com/daniissac/servelite/commit/7157847d5b311205838f4a1e80794086b485db26))
+
+
+
+## [1.0.2](https://github.com/daniissac/servelite/compare/v1.0.1...v1.0.2) (2024-11-17)
+
+
+### Bug Fixes
+
+* simplify workflow and use GITHUB_TOKEN ([4f763a3](https://github.com/daniissac/servelite/commit/4f763a3f34adff5ff25c619c4b0fba44cd2108d8))
+* update checkout action configuration ([27fa761](https://github.com/daniissac/servelite/commit/27fa76178dbd4fe4381450ef99d36744d5929965))
+* update version workflow to use GH_TOKEN ([83276ec](https://github.com/daniissac/servelite/commit/83276ecb5636ac42f33ec71c48d5c77773c67b2f))
+
+
+
+## [1.0.1](https://github.com/daniissac/servelite/compare/v1.0.0...v1.0.1) (2024-11-17)
+
+
+### Bug Fixes
+
+* update quality workflow ([c2ad11a](https://github.com/daniissac/servelite/commit/c2ad11a78549312846ad1ed13b0fac7fd9f5f600))
+
+
+
+# [1.0.0](https://github.com/daniissac/servelite/compare/06f404b7e1538e46f2d82251b8638d52c2074417...v1.0.0) (2024-11-17)
+
+
+### Bug Fixes
+
+* add write permissions to release workflow ([06f404b](https://github.com/daniissac/servelite/commit/06f404b7e1538e46f2d82251b8638d52c2074417))
+
+
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "servelite",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "A minimalist system tray application for easily sharing local directories",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servelite"
-version = "1.0.0"
+version = "1.0.4"
 description = "A lightweight system tray development server"
 authors = ["Codeium"]
 license = "MIT"


### PR DESCRIPTION
This PR updates the version to 1.0.4

Changes:
### Bug Fixes

* improve GitHub Actions workflows and fix Tauri configuration ([4b171c6](https://github.com/daniissac/servelite/commit/4b171c6fe1548c9c7c0bceb80db39546f270d9cb))