### PR TITLE
chore: release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.1.1](https://github.com/daniissac/servelite/compare/v1.1.0...v1.1.1) (2024-11-18)
+
+
+### Bug Fixes
+
+* improve error handling and fix clippy warnings ([ecda24f](https://github.com/daniissac/servelite/commit/ecda24f1db63f8d0502192f999c5eb7e131a7ace))
+
+
+
+# [1.1.0](https://github.com/daniissac/servelite/compare/v1.0.5...v1.1.0) (2024-11-17)
+
+
 ### Features
 
 * add auto-merge for version PRs ([30d321d](https://github.com/daniissac/servelite/commit/30d321d42d8c126ccda9cda18660cc1dec5ba46a))
@@ -29,3 +41,6 @@
 
 * simplify checkout configuration ([2a1a9f5](https://github.com/daniissac/servelite/commit/2a1a9f5b10e691618de7bce76bcf0d81a3b49ca3))
 * use PAT_TOKEN for workflow authentication ([7157847](https://github.com/daniissac/servelite/commit/7157847d5b311205838f4a1e80794086b485db26))
+
+
+

--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.4.0"
-  }
+  },
+  "version": "1.1.1"
 }


### PR DESCRIPTION
This PR updates the version to 1.1.1

Changes:
### Bug Fixes

* improve error handling and fix clippy warnings ([ecda24f](https://github.com/daniissac/servelite/commit/ecda24f1db63f8d0502192f999c5eb7e131a7ace))