### PR TITLE
chore: release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,26 @@
-## [1.1.1](https://github.com/daniissac/servelite/compare/v1.1.0...v1.1.1) (2024-11-18)
+# 0.1.0 (2024-11-18)
 
 
 ### Bug Fixes
 
+* add version field to Cargo.toml ([c29b742](https://github.com/daniissac/servelite/commit/c29b742afafa1818fb210c7bd954bb5e7317fc41))
+* add write permissions to release workflow ([06f404b](https://github.com/daniissac/servelite/commit/06f404b7e1538e46f2d82251b8638d52c2074417))
+* disable updater for initial v1.0.0 release ([34b26cc](https://github.com/daniissac/servelite/commit/34b26cc7f83336423c94ddb6ae3d90bd2f0b59a6))
 * improve error handling and fix clippy warnings ([ecda24f](https://github.com/daniissac/servelite/commit/ecda24f1db63f8d0502192f999c5eb7e131a7ace))
-
-
-
-# [1.1.0](https://github.com/daniissac/servelite/compare/v1.0.5...v1.1.0) (2024-11-17)
+* improve GitHub Actions workflows ([eafcf91](https://github.com/daniissac/servelite/commit/eafcf916638da8de8659d5e6d4180c06e319e54e))
+* improve GitHub Actions workflows and fix Tauri configuration ([4b171c6](https://github.com/daniissac/servelite/commit/4b171c6fe1548c9c7c0bceb80db39546f270d9cb))
+* remove updater feature to match tauri.conf.json allowlist ([a2bb3a5](https://github.com/daniissac/servelite/commit/a2bb3a523b8bffc85dde7e6e3d85527560e80463))
+* simplify checkout configuration ([2a1a9f5](https://github.com/daniissac/servelite/commit/2a1a9f5b10e691618de7bce76bcf0d81a3b49ca3))
+* simplify workflow and use GITHUB_TOKEN ([4f763a3](https://github.com/daniissac/servelite/commit/4f763a3f34adff5ff25c619c4b0fba44cd2108d8))
+* update checkout action configuration ([27fa761](https://github.com/daniissac/servelite/commit/27fa76178dbd4fe4381450ef99d36744d5929965))
+* update quality workflow ([c2ad11a](https://github.com/daniissac/servelite/commit/c2ad11a78549312846ad1ed13b0fac7fd9f5f600))
+* update version workflow to use GH_TOKEN ([83276ec](https://github.com/daniissac/servelite/commit/83276ecb5636ac42f33ec71c48d5c77773c67b2f))
+* use PAT_TOKEN for workflow authentication ([7157847](https://github.com/daniissac/servelite/commit/7157847d5b311205838f4a1e80794086b485db26))
 
 
 ### Features
 
 * add auto-merge for version PRs ([30d321d](https://github.com/daniissac/servelite/commit/30d321d42d8c126ccda9cda18660cc1dec5ba46a))
-
-
-
-## [1.0.5](https://github.com/daniissac/servelite/compare/v1.0.4...v1.0.5) (2024-11-17)
-
-
-### Bug Fixes
-
-* improve GitHub Actions workflows ([eafcf91](https://github.com/daniissac/servelite/commit/eafcf916638da8de8659d5e6d4180c06e319e54e))
-
-
-
-## [1.0.4](https://github.com/daniissac/servelite/compare/v1.0.3...v1.0.4) (2024-11-17)
-
-
-### Bug Fixes
-
-* improve GitHub Actions workflows and fix Tauri configuration ([4b171c6](https://github.com/daniissac/servelite/commit/4b171c6fe1548c9c7c0bceb80db39546f270d9cb))
-
-
-
-## [1.0.3](https://github.com/daniissac/servelite/compare/v1.0.2...v1.0.3) (2024-11-17)
-
-
-### Bug Fixes
-
-* simplify checkout configuration ([2a1a9f5](https://github.com/daniissac/servelite/commit/2a1a9f5b10e691618de7bce76bcf0d81a3b49ca3))
-* use PAT_TOKEN for workflow authentication ([7157847](https://github.com/daniissac/servelite/commit/7157847d5b311205838f4a1e80794086b485db26))
 
 
 

--- a/package.json
+++ b/package.json
@@ -12,5 +12,5 @@
   "devDependencies": {
     "@tauri-apps/cli": "^1.4.0"
   },
-  "version": "1.1.1"
+  "version": "0.1.0"
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servelite"
-version = "1.0.0"
+version = "0.1.0"
 description = "A lightweight system tray development server"
 authors = ["Codeium"]
 license = "MIT"


### PR DESCRIPTION
This PR updates the version to 0.1.0

Changes:
### Bug Fixes

* add version field to Cargo.toml ([c29b742](https://github.com/daniissac/servelite/commit/c29b742afafa1818fb210c7bd954bb5e7317fc41))
* add write permissions to release workflow ([06f404b](https://github.com/daniissac/servelite/commit/06f404b7e1538e46f2d82251b8638d52c2074417))
* disable updater for initial v1.0.0 release ([34b26cc](https://github.com/daniissac/servelite/commit/34b26cc7f83336423c94ddb6ae3d90bd2f0b59a6))
* improve error handling and fix clippy warnings ([ecda24f](https://github.com/daniissac/servelite/commit/ecda24f1db63f8d0502192f999c5eb7e131a7ace))
* improve GitHub Actions workflows ([eafcf91](https://github.com/daniissac/servelite/commit/eafcf916638da8de8659d5e6d4180c06e319e54e))
* improve GitHub Actions workflows and fix Tauri configuration ([4b171c6](https://github.com/daniissac/servelite/commit/4b171c6fe1548c9c7c0bceb80db39546f270d9cb))
* remove updater feature to match tauri.conf.json allowlist ([a2bb3a5](https://github.com/daniissac/servelite/commit/a2bb3a523b8bffc85dde7e6e3d85527560e80463))
* simplify checkout configuration ([2a1a9f5](https://github.com/daniissac/servelite/commit/2a1a9f5b10e691618de7bce76bcf0d81a3b49ca3))
* simplify workflow and use GITHUB_TOKEN ([4f763a3](https://github.com/daniissac/servelite/commit/4f763a3f34adff5ff25c619c4b0fba44cd2108d8))
* update checkout action configuration ([27fa761](https://github.com/daniissac/servelite/commit/27fa76178dbd4fe4381450ef99d36744d5929965))
* update quality workflow ([c2ad11a](https://github.com/daniissac/servelite/commit/c2ad11a78549312846ad1ed13b0fac7fd9f5f600))
* update version workflow to use GH_TOKEN ([83276ec](https://github.com/daniissac/servelite/commit/83276ecb5636ac42f33ec71c48d5c77773c67b2f))
* use PAT_TOKEN for workflow authentication ([7157847](https://github.com/daniissac/servelite/commit/7157847d5b311205838f4a1e80794086b485db26))


### Features

* add auto-merge for version PRs ([30d321d](https://github.com/daniissac/servelite/commit/30d321d42d8c126ccda9cda18660cc1dec5ba46a))